### PR TITLE
Fix log4net configuration error

### DIFF
--- a/Helper.cs
+++ b/Helper.cs
@@ -74,7 +74,7 @@ namespace EPi.Libraries.BlockSearch
             this.ContentRepository = serviceLocator.GetInstance<IContentRepository>();
             this.ContentSoftLinkRepository = serviceLocator.GetInstance<IContentSoftLinkRepository>();
             this.ContentTypeRepository = serviceLocator.GetInstance<IContentTypeRepository>();
-			this.Logger = LogManager.GetLogger();
+            this.Logger = LogManager.GetLogger();
         }
 
         /// <summary>

--- a/Helper.cs
+++ b/Helper.cs
@@ -74,7 +74,7 @@ namespace EPi.Libraries.BlockSearch
             this.ContentRepository = serviceLocator.GetInstance<IContentRepository>();
             this.ContentSoftLinkRepository = serviceLocator.GetInstance<IContentSoftLinkRepository>();
             this.ContentTypeRepository = serviceLocator.GetInstance<IContentTypeRepository>();
-            this.Logger = serviceLocator.GetInstance<ILogger>();
+			this.Logger = LogManager.GetLogger();
         }
 
         /// <summary>

--- a/SearchInitialization.cs
+++ b/SearchInitialization.cs
@@ -68,7 +68,7 @@ namespace EPi.Libraries.BlockSearch
                 return;
             }
 
-			this.Logger = LogManager.GetLogger();
+            this.Logger = LogManager.GetLogger();
             this.ContentEvents = context.Locate.Advanced.GetInstance<IContentEvents>();
             
             this.Helper = new Helper(serviceLocator: context.Locate.Advanced);

--- a/SearchInitialization.cs
+++ b/SearchInitialization.cs
@@ -68,7 +68,7 @@ namespace EPi.Libraries.BlockSearch
                 return;
             }
 
-            this.Logger = context.Locate.Advanced.GetInstance<ILogger>();
+			this.Logger = LogManager.GetLogger();
             this.ContentEvents = context.Locate.Advanced.GetInstance<IContentEvents>();
             
             this.Helper = new Helper(serviceLocator: context.Locate.Advanced);


### PR DESCRIPTION
I was receiving a configuration error in Episerver 11. Switching from `ServiceLocator.GetInstance<ILogger>()` to `LogManager.GetLogger()` resolved the issue.